### PR TITLE
fix: short email bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ class MaskData {
       maskedEmail = email;
     }
     if(!maskedEmail) {
+      if (maskLengthBeforeAtTheRate < 0) maskLengthBeforeAtTheRate = 0
       maskedEmail = email.substr(0, options.unmaskedStartCharacters) + `${options.maskWith}`.repeat(maskLengthBeforeAtTheRate)
         + '@' + `${options.maskWith}`.repeat(maskLengthAfterAtTheRate) + email.substr(email.length - options.unmaskedEndCharacters);
     }

--- a/test.js
+++ b/test.js
@@ -38,6 +38,12 @@ console.log(`Unmasked email: ${email}`);
 console.log(`Email after masking: ${MaskData.maskEmail(email, defaultEmailMaskOptions)}`);
 console.log("========================================");
 
+console.log("========================================");
+const shortEmail = "my@test.com";
+console.log(`Unmasked shortEmail: ${shortEmail}`);
+console.log(`shortEmail after masking: ${MaskData.maskEmail(shortEmail, defaultEmailMaskOptions)}`);
+console.log("========================================");
+
 const defaultJSONMaskOptions = {
   fields: ['password', 'firstName']
 };


### PR DESCRIPTION
there is a bug when the email address before the `@` is too short, this addresses the issue
# Expected Behavior

should mask email addresses with default options `simpleEmailMask`

# Current Behavior

fails when the email is short

# Failure Information (for bugs)

```
      maskedEmail = email.substr(0, options.unmaskedStartCharacters) + `${options.maskWith}`.repeat(maskLengthBeforeAtTheRate)
                                                                                             ^

RangeError: Invalid count value
    at String.repeat (<anonymous>)
    at Function.maskEmail (/Users/justice/workspace/p/maskdata/index.js:110:94)
    at Object.<anonymous> (/Users/justice/workspace/p/maskdata/test.js:44:46)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
```

## Steps to Reproduce

Please provide detailed steps for reproducing the issue.

1. set email to `hi@awesomewebsite.com`
2. call `simpleEmailMask`

## Context

Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.

* version (master)

