### PR TITLE
Changes to support partial mask for Json

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ const defaultPhoneMaskOptions = {
 
 const defaultJsonMaskOptions = {
   maskWith: "*",
+  unmaskedStartDigits: 0,
+  unmaskedEndDigits: 0,
   fields: []
 };
 
@@ -110,8 +112,14 @@ class MaskData {
         } else {
           const value = get(maskedObj, field);
           if(value !== undefined && value !== null) {
-          set(maskedObj, field, (`${options.maskWith}`.repeat(value.toString().length)))
-        }
+            if((options.unmaskedStartDigits + options.unmaskedEndDigits) >= value.length) {
+              set(maskedObj, field, (`${options.maskWith}`.repeat(value.toString().length)))
+            }else{
+              let maskLength = value.length - options.unmaskedStartDigits - options.unmaskedEndDigits;
+              set(maskedObj, field, (value.substr(0, options.unmaskedStartDigits) + `${options.maskWith}`.repeat(maskLength) + value.substr(value.length-options.unmaskedEndDigits)))  
+            }
+          
+          }
         }
       } catch(ex) { continue; }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maskdata",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Node module to mask various kinds of data in required formats",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The current implementation doesn't support partial masking for JSON attributes. It is a quick change, but this needs to improve as it only supports simple attributes and no wildcards.  But can be a starting point for this feature.