### PR TITLE
update lodash dependency to fix possible prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@
 const MaskHelper = require('./lib/helpers/MaskHelper');
 const MaskEmail = require('./lib/emailMask/EmailMask');
 const MaskCard = require('./lib/cardMask/CardMask');
-const get = require('lodash.get');
-const set = require('lodash.set');
+const {get, set} = require('lodash');
 
 const defaultPhoneMaskOptions = {
   maskWith: "*",
@@ -58,7 +57,7 @@ class MaskData {
         const remainingChars = maskPasswordLength - options.unmaskedStartCharacters;
         for(let i = password.length-remainingChars; i < password.length; i++) {
           maskedPassword += password[i];
-        } 
+        }
         return maskedPassword;
       }
     }
@@ -67,7 +66,7 @@ class MaskData {
     maskedPassword += `${options.maskWith}`.repeat(maskingCharacters)
     for(let i = password.length-options.unmaskedEndCharacters; i < password.length; i++) {
       maskedPassword += password[i];
-    } 
+    }
     return maskedPassword;
   }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "author": "sumukha.s<sumukha.hs369@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
As the modular lodash packages are not maintained anymore and do not get any security updates i changed the `lodash.get` and `lodash.set` package back to the latest `lodash`.

Currently for `lodash.set` a security warnings with a HIGH score is flagged with security scanner. There is a prototyp pollution possible that is fixed with latest lodash package. As the parameter supplied to the `set()` method are provided by users of your library and you cannot control where their input is coming from (e.g. network or similar) this is an exploitable security issue.

The update to latests full `lodash` fixes this attack vector.

more information can be found at https://security.snyk.io/vuln/SNYK-JS-LODASHSET-1320032