### PR TITLE
add mocha tests for card, email, password, phone, string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 package-lock.json
-node_modules
+node_modules/
+.nyc_output/
+coverage/
 .vs*
+.idea/
+/*.iml

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/Sumukha1496/maskdata"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js && mocha --timeout 5000 --exit",
+    "coverage": "nyc --reporter=lcov --report-dir coverage/ mocha --timeout 5000 --reporter mocha-junit-reporter --reporter-options mochaFile=coverage/junit.xml --exit"
   },
   "keywords": [
     "mask",
@@ -32,5 +33,11 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
+  },
+  "devDependencies": {
+    "mocha": "^9.2.2",
+    "mocha-junit-reporter": "^2.0.2",
+    "chai": "^4.3.6",
+    "nyc": "^15.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,57 +1,5 @@
 const MaskData = require('./index');
 
-const passwordMaskOptions = {
-  maxMaskedCharacters: 10,
-  maskWith: "X",
-  unmaskedStartCharacters: 7,
-  unmaskedEndCharacters: 3
-};
-
-const password = "Password1$";
-console.log(`Unmasked Password: ${password}` + " Length: " + password.length);
-const maskedP = MaskData.maskPassword(password, passwordMaskOptions);
-console.log("Password after masking:" + maskedP + " Length: " + maskedP.length);
-console.log("========================================");
-const maskedPD = MaskData.maskPassword(password);
-console.log("Password after masking with default options:" + maskedPD + " Length: " + maskedPD.length);
-console.log("========================================");
-
-
-const phoneMaskOptions = {
-  maskWith: "*",
-  unmaskedStartDigits: 5,
-  unmaskedEndDigits: 1
-};
-
-const phone = "+91123456789";
-
-console.log(`Unmasked phone: ${phone}`);
-console.log(`phone after masking: ${MaskData.maskPhone(phone, phoneMaskOptions)}`);
-console.log("========================================");
-console.log(`phone after masking with default options: ${MaskData.maskPhone(phone)}`);
-console.log("========================================");
-
-const emailMask2Options = {
-  maskWith: "*",
-  unmaskedStartCharactersBeforeAt: 0,
-  unmaskedEndCharactersAfterAt: 99,
-  maskAtTheRate: false
-};
-
-console.log("========================================");
-const email = "my.testEmail@testMail.com";
-console.log(`Unmasked email: ${email}`);
-console.log(`Email after masking: ${MaskData.maskEmail2(email, emailMask2Options)}`);
-console.log("========================================");
-console.log(`Email after masking with default options: ${MaskData.maskEmail2(email)}`);
-console.log("========================================");
-
-console.log("========================================");
-const shortEmail = "a@b.c";
-console.log(`Unmasked shortEmail: ${shortEmail}`);
-console.log(`shortEmail after masking: ${MaskData.maskEmail2(shortEmail, emailMask2Options)}`);
-console.log("========================================");
-
 const jsonMaskOptions = {
   fields: ['password', 'firstName']
 };
@@ -119,59 +67,6 @@ console.log(`Nested Object after masking:`);
 console.log(JSON.stringify(MaskData.maskJSONFields(nestedObject, jsonMaskOptions2)));
 console.log("========================================");
 
-
-const stringMaskOptions = {
-  maskWith: "*",
-  values: ['is', 'API']
-};
-
-const fullStringMaskOptions = {
-  maskWith: "*",
-  values: ['is', 'API'],
-  maskAll: true
-};
-
-const fullStringMaskOptionsWithoutSpace = {
-  maskWith: "*",
-  values: ['is', 'API'],
-  maskAll: true,
-  maskSpace: false
-};
-
-let str = "This is a testingAPI String";
-console.log(`Unmasked string: ${str}`);
-console.log(`String after masking: ${MaskData.maskString(str, stringMaskOptions)}`);
-console.log("========================================");
-
-str = "This is a testingAPI String";
-stringMaskOptions.maskOnlyFirstOccurance = true;
-console.log(`Unmasked string: ${str}`);
-console.log(`String after masking entire string: ${MaskData.maskString(str, fullStringMaskOptions)}`);
-console.log("========================================");
-
-str = "This is a testingAPI String";
-stringMaskOptions.maskOnlyFirstOccurance = true;
-console.log(`Unmasked string: ${str}`);
-console.log(`String after masking only first occurances: ${MaskData.maskString(str, stringMaskOptions)}`);
-console.log("========================================");
-
-str = "This is a testingAPI String";
-stringMaskOptions.maskOnlyFirstOccurance = true;
-console.log(`Unmasked string: ${str}`);
-console.log(`String after masking entire string without spaces: ${MaskData.maskString(str, fullStringMaskOptionsWithoutSpace)}`);
-console.log("========================================");
-
-const cardMaskOptions = {
-  maskWith: "X",
-  unmaskedStartDigits: 4,
-  unmaskedEndDigits: 5
-};
-
-let cardNumber = "1234-5678-1234-5678";
-console.log(`Unmasked cardNumber: ${cardNumber}`);
-console.log(`cardNumber after masking: ${MaskData.maskCard(cardNumber, cardMaskOptions)}`);
-console.log("========================================");
-
 const nestedJson = {
   level1: {
     field1: "field1",
@@ -207,7 +102,7 @@ console.log("Type of married: "+ typeof(afterReplacing.married));
 
 const maskCardOptions = {
   maskWith: "*",
-  unmaskedStartDigits: 4, 
+  unmaskedStartDigits: 4,
   unmaskedEndDigits: 4
 };
 

--- a/tests/testCard.js
+++ b/tests/testCard.js
@@ -1,0 +1,161 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking card numbers', function() {
+
+  describe('Mask with default options', function() {
+
+    // default options are this - let tests fail when defaults change
+    // const defaultCardMaskOptions = {
+    //   maskWith: '*',
+    //   unmaskedStartDigits: 4,
+    //   unmaskedEndDigits: 1
+    // };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: '1234-5678-1234-5678',
+        output: '1234-****-****-***8'
+      },
+      {
+        title: 'test string length equal than start + end',
+        input: '123-4',
+        output: '123-4'
+      },
+      {
+        title: 'test shorter string than start + end',
+        input: '1234',
+        output: '1234'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskCard(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options', function() {
+
+    const maskOptions = {
+      maskWith: 'x',
+      unmaskedStartDigits: 2,  // use different numbers for start / end to check correct masking
+      unmaskedEndDigits: 3
+    };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: '1234-5678-1234-5678',
+        output: '12xx-xxxx-xxxx-x678'
+      },
+      {
+        title: 'test string length equal than start + end',
+        input: '12-345',
+        output: '12-345'
+      },
+      {
+        title: 'test shorter string than start + end',
+        input: '1234',
+        output: '1234'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskCard(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+
+    it('test with negative unmaskedStartDigits', function() {
+      const negativeStartOption = {
+        maskWith: 'x',
+        unmaskedStartDigits: -2,    // internal set to 0
+        unmaskedEndDigits: 3
+      }
+      const input = '1234-5678-1234-5678'
+      const output = 'xxxx-xxxx-xxxx-x678'
+      const masked = maskData.maskCard(input, negativeStartOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+
+    it('test with negative unmaskedEndDigits', function() {
+      const negativeEndOption = {
+        maskWith: 'x',
+        unmaskedStartDigits: 2,
+        unmaskedEndDigits: -3  // internal set to 0
+      }
+      const input = '1234-5678-1234-5678'
+      const output = '12xx-xxxx-xxxx-xxxx'
+      const masked = maskData.maskCard(input, negativeEndOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+  });
+
+  describe('Mask with special input strings', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      unmaskedStartDigits: 2,
+      unmaskedEndDigits: 3
+    };
+
+    describe('Mask with special input - input will generate an output', function() {
+
+      // first set with input generating an masked output
+      let testData = [
+        {
+          title: 'test with string length zero',
+          input: '',
+          output: ''
+        },
+        {
+          title: 'test input null',
+          input: null,
+          output: null
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+
+    describe('Mask with special input - input shall throw error', function() {
+
+      // set with input generating an error / exception
+      let testData = [
+        {
+          title: 'test input as number',
+          input: 12,
+          output: '12'
+        },
+        {
+          title: 'test input as array',
+          input: ['12'],
+          output: '12'
+        },
+        {
+          title: 'test input as object',
+          input: {a: 'b', x: 'y'},
+          output: '12'
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+  });
+});

--- a/tests/testEmail.js
+++ b/tests/testEmail.js
@@ -1,0 +1,235 @@
+'use strict';
+const maskData = require('../index');
+const BadOption = require('../lib/ExceptionsHandler/BadOption');
+const expect = require('chai').expect;
+
+describe('Masking email addresses', function() {
+
+  describe('Mask with default options', function() {
+
+    // default options are this - let tests fail when defaults change
+    // const defaultCardMaskOptions = {
+    //   maskWith: '*',
+    //   unmaskedStartCharactersBeforeAt: 3,
+    //   unmaskedEndCharactersAfterAt: 2
+    //   maskAtTheRate: false
+    // };
+
+    let testData = [
+      {
+        title: 'test standard address',
+        input: 'testuser@dummy.org',
+        output: 'tes*****@*******rg'
+      },
+      {
+        title: 'test user part shorter than chars before',
+        input: 'we@dummy.org',
+        output: 'we@*******rg'
+      },
+      {
+        title: 'test user part equal to chars before',
+        input: 'you@dummy.org',
+        output: 'you@*******rg'
+      },
+      {
+        title: 'test no user part and domain only',
+        input: '@dummy.org',
+        output: '@*******rg'
+      },
+      {
+        title: 'test no domain part and user only',
+        input: 'user@',
+        output: 'use*@'
+      },
+      {
+        title: 'test domain part shorter than chars after',
+        input: 'user@x',
+        output: 'use*@x'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskEmail2(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options (char, before, after)', function() {
+
+    const maskOptions = {
+      maskWith: 'x',
+      unmaskedStartCharactersBeforeAt: 4,
+      unmaskedEndCharactersAfterAt: 6,    // full tld and part of sld
+      maskAtTheRate: false
+    };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: 'testuser@dummy.org',
+        output: 'testxxxx@xxxmy.org'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskEmail2(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options (maskAtTheRate)', function() {
+
+    const maskOptions = {
+      maskWith: '*',
+      unmaskedStartCharactersBeforeAt: 4,
+      unmaskedEndCharactersAfterAt: 6,    // full tld and part of sld
+      maskAtTheRate: true
+    };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: 'testuser@dummy.org',
+        output: 'test********my.org'
+      },
+      {
+        title: 'test user and domain part to short',
+        input: 'we@a.de',
+        output: 'we*a.de'   // before and after are shorter than visible, only @ replaced
+      },
+      {
+        title: 'test user part to short',
+        input: 'we@dummy.org',
+        output: 'we****my.org'   // before and after are shorter than visible, only @ replaced
+      },
+      {
+        title: 'test domain part to short',
+        input: 'testuser@a.de',
+        output: 'test*****a.de'   // before and after are shorter than visible, only @ replaced
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskEmail2(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+
+    it('custom mask - negative start digits', function() {
+      const negativeStartOptions = {
+        maskWith: '*',
+        unmaskedStartCharactersBeforeAt: -1,  // replaced with 0 internally
+        unmaskedEndCharactersAfterAt: 1,
+        maskAtTheRate: false
+      };
+      const input = 'test@dummy.de';
+      const output = '****@*******e';
+      const masked = maskData.maskEmail2(input, negativeStartOptions);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+
+    it('custom mask - negative end digits', function() {
+      const negativeEndOptions = {
+        maskWith: '*',
+        unmaskedStartCharactersBeforeAt: 1,  // replaced with 0 internally
+        unmaskedEndCharactersAfterAt: -1,
+        maskAtTheRate: false
+      };
+      const input = 'test@dummy.de';
+      const output = 't***@********';
+      const masked = maskData.maskEmail2(input, negativeEndOptions);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+  });
+
+  describe('test error cases for email addresses', function() {
+
+    let testData = [
+      {
+        title: 'test no email address at all',
+        input: 'user-dummy.org',
+        output: 'use*@x'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        try {
+          const masked = maskData.maskEmail2(input);
+          expect.fail('maskEmail2 should throw error');
+        }
+        catch(e) {
+          expect(e).to.be.a('string').and.match(/Bad config.*Email must.*@/);
+        }
+      });
+    })
+  });
+
+  describe('Mask with special input strings', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      unmaskedStartCharactersBeforeAt: 1,
+      unmaskedEndCharactersAfterAt: 1,
+      maskAtTheRate: false
+    };
+
+    describe('Mask with special input - input will generate an output', function() {
+
+      // first set with input generating an masked output
+      let testData = [
+        {
+          title: 'test with string length zero',
+          input: '',
+          output: ''
+        },
+        {
+          title: 'test input null',
+          input: null,
+          output: null
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+
+    describe('Mask with special input - input shall throw error', function() {
+
+      // set with input generating an error / exception
+      let testData = [
+        {
+          title: 'test input as number',
+          input: 12,
+          output: '12'
+        },
+        {
+          title: 'test input as array',
+          input: ['12'],
+          output: '12'
+        },
+        {
+          title: 'test input as object',
+          input: {a: 'b', x: 'y'},
+          output: '12'
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+  });
+});

--- a/tests/testJsonFields.js
+++ b/tests/testJsonFields.js
@@ -1,0 +1,9 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking JSON fields', function() {
+
+  // TODO - migrate all tests from test.js into mocha tests to fail on error
+  // TODO - extend tests
+});

--- a/tests/testPassword.js
+++ b/tests/testPassword.js
@@ -1,0 +1,183 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking password', function() {
+
+  describe('Mask with default options', function() {
+
+    // default options are this - let tests fail when defaults change
+    // const defaultPasswordMaskOptions = {
+    //   maskWith: "*",
+    //   maxMaskedCharacters: 16,
+    //   unmaskedStartCharacters: 0,
+    //   unmaskedEndCharacters: 0
+    // };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: '1234-5678-1234-5678',
+        output: '****************'    // equal maxMaskedChars
+      },
+      {
+        title: 'test string shorter than maxMasked',
+        input: '123-4',
+        output: '*****'
+      },
+      {
+        title: 'test longer than maxMasked',
+        input: '1234567890abcdefghijkl',
+        output: '****************'    // equal maxMaskedChars
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskPassword(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options - maskWith, maxMaskedChars', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      maxMaskedCharacters: 6,
+      unmaskedStartCharacters: 1,  // use different numbers for start / end to check correct masking
+      unmaskedEndCharacters: 2
+    };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: '1234-5678-1234-5678',
+        output: '1xxx78'
+      },
+      {
+        title: 'test string length equal than start + end',
+        input: '12-345',
+        output: '1xxx45'
+      },
+      {
+        title: 'test shorter string than start + end',
+        input: '12',
+        output: '12'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskPassword(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+
+    it('custom mask - test with negative unmaskedStartDigits', function() {
+      const negativeStartOption = {
+        maskWith: 'x',
+        maxMaskedCharacters: 6,
+        unmaskedStartCharacters: -2,    // internal set to 0
+        unmaskedEndCharacters: 2
+      }
+      const input = '1234-5678-1234-5678'
+      const output = 'xxxx78'
+      const masked = maskData.maskPassword(input, negativeStartOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+
+    it('custom mask - test with maxMasked shorter than start + end', function() {
+      // TODO - should this throw an error? there is no masking at all
+      const shortMaxCharsOption = {
+        maskWith: 'x',
+        maxMaskedCharacters: 6,
+        unmaskedStartCharacters: 4,    // 4+4=8 > 6
+        unmaskedEndCharacters: 4
+      }
+      const input = '1234-5678-1234-5678'
+      const output = '123478'
+      const masked = maskData.maskPassword(input, shortMaxCharsOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+      expect.fail('Shall this test fail because options prevent full masking?')
+    });
+
+    it('custom mask - test with maxMasked equal than start + end', function() {
+      // TODO - should this throw an error? there is no masking at all
+      const shortMaxCharsOption = {
+        maskWith: 'x',
+        maxMaskedCharacters: 8,
+        unmaskedStartCharacters: 4,    // 4+4=8
+        unmaskedEndCharacters: 4
+      }
+      const input = '1234-abcd-efgh-5678'
+      const output = '12345678'
+      const masked = maskData.maskPassword(input, shortMaxCharsOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+      expect.fail('Shall this test fail because options prevent full masking?')
+    });
+  });
+
+  describe('Mask with special input strings', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      maxMaskedCharacters: 6,
+      unmaskedStartCharacters: 2,
+      unmaskedEndCharacters: 2
+    };
+
+    describe('Mask with special input - input will generate an output', function() {
+
+      // first set with input generating an masked output
+      let testData = [
+        {
+          title: 'test with string length zero',
+          input: '',
+          output: ''
+        },
+        {
+          title: 'test input null',
+          input: null,
+          output: null
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+
+    describe('Mask with special input - input shall throw error', function() {
+
+      // set with input generating an error / exception
+      let testData = [
+        {
+          title: 'test input as number',
+          input: 12,
+          output: '12'
+        },
+        {
+          title: 'test input as array',
+          input: ['12'],
+          output: '12'
+        },
+        {
+          title: 'test input as object',
+          input: {a: 'b', x: 'y'},
+          output: '12'
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPassword(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+  });
+});

--- a/tests/testPhone.js
+++ b/tests/testPhone.js
@@ -1,0 +1,161 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking phone numbers', function() {
+
+  describe('Mask with default options', function() {
+
+    // default options are this - let tests fail when defaults change
+    // const phoneMaskOptions = {
+    //   maskWith: "*",
+    //   unmaskedStartDigits: 4,
+    //   unmaskedEndDigits: 1
+    // };
+
+    let testData = [
+      {
+        title: 'test default number',
+        input: '1234-56781234',
+        output: '1234********4'
+      },
+      {
+        title: 'test number length equal than start + end',
+        input: '12345',
+        output: '12345'
+      },
+      {
+        title: 'test shorter number than start + end',
+        input: '1234',
+        output: '1234'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskPhone(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options', function() {
+
+    const maskOptions = {
+      maskWith: 'x',
+      unmaskedStartDigits: 2,  // use different numbers for start / end to check correct masking
+      unmaskedEndDigits: 3
+    };
+
+    let testData = [
+      {
+        title: 'test default string',
+        input: '1234-5678-1234-5678',
+        output: '12xxxxxxxxxxxxxx678'
+      },
+      {
+        title: 'test number length equal than start + end',
+        input: '12-34',
+        output: '12-34'
+      },
+      {
+        title: 'test shorter number than start + end',
+        input: '1234',
+        output: '1234'
+      }
+    ]
+
+    testData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskPhone(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+
+    it('test with negative unmaskedStartDigits', function() {
+      const negativeStartOption = {
+        maskWith: 'x',
+        unmaskedStartDigits: -2,    // internal set to 0
+        unmaskedEndDigits: 3
+      }
+      const input = '1234-5678'
+      const output = 'xxxxxx678'
+      const masked = maskData.maskPhone(input, negativeStartOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+
+    it('test with negative unmaskedEndDigits', function() {
+      const negativeEndOption = {
+        maskWith: 'x',
+        unmaskedStartDigits: 2,
+        unmaskedEndDigits: -3  // internal set to 0
+      }
+      const input = '1234-5678'
+      const output = '12xxxxxxx'
+      const masked = maskData.maskPhone(input, negativeEndOption);
+      expect(masked).to.equal(output, 'masked output does not match expected value');
+    });
+  });
+
+  describe('Mask with special input strings', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      unmaskedStartDigits: 2,
+      unmaskedEndDigits: 2
+    };
+
+    describe('Mask with special input - input will generate an output', function() {
+
+      // first set with input generating an masked output
+      let testData = [
+        {
+          title: 'test with string length zero',
+          input: '',
+          output: ''
+        },
+        {
+          title: 'test input null',
+          input: null,
+          output: null
+        },
+        {
+          title: 'test input as number',
+          input: 1234567,
+          output: 'xx'      // TODO - ok to convert number into string? Or should it fail?
+        },
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPhone(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+
+    describe('Mask with special input - input shall throw error', function() {
+
+      // set with input generating an error / exception
+      let testData = [
+        {
+          title: 'test input as array',
+          input: ['12', '34'],
+          output: 'xx'
+        },
+        {
+          title: 'test input as object',
+          input: {a: 'b', x: 'y'},
+          output: '12'
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskPhone(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+  });
+});

--- a/tests/testReplaceValue.js
+++ b/tests/testReplaceValue.js
@@ -1,0 +1,9 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Test replaceValue', function() {
+
+  // TODO - migrate all tests from test.js into mocha tests to fail on error
+  // TODO - extend tests
+});

--- a/tests/testString.js
+++ b/tests/testString.js
@@ -1,0 +1,258 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking strings', function() {
+
+  // common strings without output - used as base for all tests below
+  let testData = [
+    {
+      title: 'test default string',
+      input: 'This is a testingAPI String',
+      output: ''
+    },
+    {
+      title: 'test string without space',
+      input: 'thisisastring',
+      output: ''
+    },
+    {
+      title: 'test string with newline',
+      input: 'this is a\nstring with newline',
+      output: ''
+    }
+  ]
+
+  describe('Mask with default options', function() {
+
+    // default options are this - let tests fail when defaults change
+    // const defaultStringMaskOptions = {
+    //   maskWith: "*",
+    //   maskOnlyFirstOccurance: false,
+    //   values: [],
+    //   maskAll: false,
+    //   maskSpace: true
+    // };
+
+    // no values -> no masking
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = localTestData[0].input;
+    localTestData[1].output = localTestData[1].input;
+    localTestData[2].output = localTestData[2].input;
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`default mask - ${title}`, function() {
+        const masked = maskData.maskString(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    })
+  });
+
+  describe('Mask with custom options - maskWith, maskSpace', function() {
+
+    // only maskWith and maskSpace set
+    const maskOptions = {
+      maskWith: "?",
+      maskOnlyFirstOccurance: false,
+      values: [],
+      maskAll: false,
+      maskSpace: true
+    };
+
+    // no values -> no masking
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = localTestData[0].input;
+    localTestData[1].output = localTestData[1].input;
+    localTestData[2].output = localTestData[2].input;
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with custom options - maskWith, maskAll, no spaces', function() {
+
+    // only maskWith, maskAll set
+    const maskOptions = {
+      maskWith: "?",
+      maskOnlyFirstOccurance: false,
+      values: [],
+      maskAll: true,
+      maskSpace: false
+    };
+
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = '???? ?? ? ?????????? ??????';
+    localTestData[1].output = '?'.repeat(localTestData[1].input.length);   // no space here
+    localTestData[2].output = '???? ?? ???????? ???? ???????';
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with custom options - maskWith multiple chars, maskAll, maskSpace', function() {
+
+    // only maskWith, maskAll set
+    const maskChar = "??";   // mask every char in input string with two chars in output
+    const maskOptions = {
+      maskWith: maskChar,
+      maskOnlyFirstOccurance: false,
+      values: [],
+      maskAll: true,
+      maskSpace: true
+    };
+
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = maskChar.repeat(localTestData[0].input.length);
+    localTestData[1].output = maskChar.repeat(localTestData[1].input.length);
+    localTestData[2].output = maskChar.repeat(localTestData[2].input.length);
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with custom options - values and maskAll set, no spaces', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      maskOnlyFirstOccurance: false,
+      values: ['is', 'ing'],
+      maskAll: true,
+      maskSpace: false
+    };
+
+    // expected: values ignored and all masked, space remains
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = 'xxxx xx x xxxxxxxxxx xxxxxx';
+    localTestData[1].output = 'x'.repeat(localTestData[1].input.length);   // no spaces here
+    localTestData[2].output = 'xxxx xx xxxxxxxx xxxx xxxxxxx';
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with custom options - values and all occurrences', function() {
+
+    const maskOptions = {
+      maskWith: "*",
+      maskOnlyFirstOccurance: false,
+      values: ['is', 'ing'],
+      maskAll: false,
+      maskSpace: true
+    };
+
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = 'Th** ** a test***API Str***';
+    localTestData[1].output = 'th****astr***';
+    localTestData[2].output = 'th** ** a\nstr*** with newline';
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with custom options - values and first occureances', function() {
+
+    const maskOptions = {
+      maskWith: "*",
+      maskOnlyFirstOccurance: true,
+      values: ['is', 'ing'],
+      maskAll: false,
+      maskSpace: true
+    };
+
+    const localTestData = JSON.parse(JSON.stringify(testData));
+    localTestData[0].output = 'Th** is a test***API String';
+    localTestData[1].output = 'th**isastr***';
+    localTestData[2].output = 'th** is a\nstr*** with newline';
+
+    localTestData.forEach(({title, input, output}) => {
+      it(`custom mask - ${title}`, function() {
+        const masked = maskData.maskString(input, maskOptions);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask with special input strings', function() {
+
+    const maskOptions = {
+      maskWith: "x",
+      maskOnlyFirstOccurance: true,
+      values: [],
+      maskAll: true,
+      maskSpace: true
+    };
+
+    describe('Mask with special input - input will generate an output', function() {
+
+      // first set with input generating an masked output
+      let testData = [
+        {
+          title: 'test with string length zero',
+          input: '',
+          output: ''
+        },
+        {
+          title: 'test input null',
+          input: null,
+          output: null
+        },
+        {
+          title: 'test input as number',
+          input: 12,
+          output: 'xx'      // TODO - ok to convert number into string? Or should it fail?
+        },
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskString(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+
+    describe('Mask with special input - input shall throw error', function() {
+
+      // set with input generating an error / exception
+      let testData = [
+        {
+          title: 'test input as array',
+          input: ['12', 'ab'],
+          output: 'xx'      // mask method seems to join all strings in the array into on big string and masks it?
+        },
+        {
+          title: 'test input as object',
+          input: {a: 'b', x: 'y'},
+          output: '12'  // json stringified and masked?
+        }
+      ]
+
+      testData.forEach(({title, input, output}) => {
+        it(`special input - ${title}`, function() {
+          const masked = maskData.maskString(input, maskOptions);
+          expect(masked).to.equal(output, 'masked output does not match expected value');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds mocha tests for some (not all) MaskData functions.

All tests done in mocha are removed from the old `test.js` file.
Not converted are the `jsonFields()` and `replaceValue()` function test. An empty mocha test file is added only for later use.

Running `npm test` now calls the old and new mocha tests.

Open Questions:
* testPassword.js -> Custom option tests: is it an error when maxMaskedChars is shorter than start and end masked chars?
  booth tests fail currently on purpose.
* What to do with the tests checking for some special / unusual input data? Currently not checked from the library and code crashing, no proper error handling available by now(and tests fail).
* library functions differ right now on handling `null` or getting numbers on input. Unify library behaviour?


Additionally i added code coverage reports derived from the mocha tests too - they can be executed via `npm run coverage` and generate an html page at `/coverage/lcov-report/index.html` The generated `/coverage/junit.xml` and `/coverage/lcov.info` from the coverage script files can be used for other tools and UIs displaying this information (sonarqube or similar).