### PR TITLE
Testcase fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ class MaskData {
     } else {
       options = defaultPhoneMaskOptions;
     }
+    if (typeof phone === 'number') phone = phone + '';
+    if (typeof phone !== 'string') throw new TypeError('Invalid phone parameter format');
     let maskLength = phone.length - options.unmaskedStartDigits - options.unmaskedEndDigits;
     if((options.unmaskedStartDigits + options.unmaskedEndDigits) >= phone.length) {
       return phone;

--- a/index.js
+++ b/index.js
@@ -35,15 +35,15 @@ const defaultStringMaskOptions = {
 class MaskData {
 
   static maskPassword(password, options) {
-    if(!password) {
-      return password;
-    }
+    if(!password) return password;
     if(options) {
       options = MaskHelper.mapWithDefaultValues(options, defaultPasswordMaskOptions);
       MaskHelper.validatePasswordOptions(options);
     } else {
       options = defaultPasswordMaskOptions;
     }
+
+    if (typeof password !== 'string') throw new TypeError('Invalid password parameter format');
     let maskPasswordLength = password.length;
     if(password.length > options.maxMaskedCharacters) {
       maskPasswordLength = parseInt(options.maxMaskedCharacters);

--- a/index.js
+++ b/index.js
@@ -161,7 +161,8 @@ class MaskData {
 
   static maskString(str, options) {
     if(!str) return str;
-    str = str + '';
+    if (typeof str === 'number') str = str + '';  // be nice, convert number to string as current implementation does
+    if (typeof str === 'object') throw new TypeError('Invalid str parameter format');
     if(options) {
       options = MaskHelper.mapWithDefaultValues(options, defaultStringMaskOptions);
       MaskHelper.validateStringOptions(options);

--- a/lib/cardMask/CardMask.js
+++ b/lib/cardMask/CardMask.js
@@ -9,6 +9,8 @@ const defaultCardMaskOptions = {
 class CardMask {
     static maskCard(card, options) {
         if(!card) return card;
+        // number converted to processable number
+        if (typeof card === 'object') throw new TypeError('Invalid card parameter format');
         let cardToProcess = (card + '').trim();
         if(options) {
           options = MaskHelper.mapWithDefaultValues(options, defaultCardMaskOptions);
@@ -50,7 +52,7 @@ class CardMask {
             }
             j++;
         }
-        
+
         i = 0;
         j = lastIndex+1;
         while(i < options.unmaskedEndDigits) {

--- a/lib/emailMask/EmailMask.js
+++ b/lib/emailMask/EmailMask.js
@@ -10,6 +10,7 @@ const defaultEmailMask2Options = {
 class EmailMask {
 
     static maskEmail2(email, options) {
+        if (!email) return email;
         let maskedEmail = '';
         options = options ? MaskHelper.mapWithDefaultValues(options, defaultEmailMask2Options) : defaultEmailMask2Options;
         MaskHelper.validateEmailOptions2(email, options);
@@ -21,12 +22,12 @@ class EmailMask {
         const beforeLength = before.length;
         const afterLength = after.length;
 
-        maskedEmail += (options.unmaskedStartCharactersBeforeAt >= beforeLength) ? before : 
+        maskedEmail += (options.unmaskedStartCharactersBeforeAt >= beforeLength) ? before :
           before.substr(0, options.unmaskedStartCharactersBeforeAt) + `${options.maskWith}`.repeat(beforeLength - options.unmaskedStartCharactersBeforeAt);
-        
+
         maskedEmail += options.maskAtTheRate ? options.maskWith : '@';
 
-        maskedEmail += (options.unmaskedEndCharactersAfterAt >= afterLength) ? after : 
+        maskedEmail += (options.unmaskedEndCharactersAfterAt >= afterLength) ? after :
           (`${options.maskWith}`.repeat(afterLength-options.unmaskedEndCharactersAfterAt) + after.substr(afterLength - options.unmaskedEndCharactersAfterAt));
         return maskedEmail;
       }

--- a/lib/helpers/MaskHelper.js
+++ b/lib/helpers/MaskHelper.js
@@ -108,10 +108,10 @@ class MaskHelper {
       badOptions.throwBadOptionException();
     }
   }
-  
+
   static validateEmailOptions2(email, options) {
     let reasons = [];
-    if(!email || email.indexOf('@') < 0) {
+    if(!email || typeof email !== 'string' || email.indexOf('@') < 0) {
       reasons.push(`Email must contain one '@'`);
     }
     try{

--- a/lib/helpers/MaskHelper.js
+++ b/lib/helpers/MaskHelper.js
@@ -17,7 +17,7 @@ class MaskHelper {
       options.maxMaskedCharacters = parseInt(options.maxMaskedCharacters);
       options.unmaskedStartCharacters = parseInt(options.unmaskedStartCharacters);
       options.unmaskedEndCharacters = parseInt(options.unmaskedEndCharacters);
-      if(isNaN(options.maxMaskedCharacters) || isNaN(options.unmaskedStartCharacters) || 
+      if(isNaN(options.maxMaskedCharacters) || isNaN(options.unmaskedStartCharacters) ||
         isNaN(options.unmaskedEndCharacters)) {
         throw Error();
       };

--- a/tests/testCard.js
+++ b/tests/testCard.js
@@ -118,12 +118,17 @@ describe('Masking card numbers', function() {
           title: 'test input null',
           input: null,
           output: null
-        }
+        },
+        {
+          title: 'test input as number',
+          input: 12,
+          output: '12'
+        },
       ]
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskPassword(input, maskOptions);
+          const masked = maskData.maskCard(input, maskOptions);
           expect(masked).to.equal(output, 'masked output does not match expected value');
         });
       });
@@ -134,13 +139,13 @@ describe('Masking card numbers', function() {
       // set with input generating an error / exception
       let testData = [
         {
-          title: 'test input as number',
-          input: 12,
+          title: 'test input as array length 1',
+          input: ['12'],
           output: '12'
         },
         {
-          title: 'test input as array',
-          input: ['12'],
+          title: 'test input as array length 2',
+          input: ['12', '34'],
           output: '12'
         },
         {
@@ -152,8 +157,14 @@ describe('Masking card numbers', function() {
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskPassword(input, maskOptions);
-          expect(masked).to.equal(output, 'masked output does not match expected value');
+          try {
+            const masked = maskData.maskCard(input, maskOptions);
+            expect.fail('maskCard shall throw an error')
+          }
+          catch(e) {
+            expect(e).to.be.instanceOf(TypeError);
+            expect(e.message).to.equal('Invalid card parameter format');
+          }
         });
       });
     });

--- a/tests/testEmail.js
+++ b/tests/testEmail.js
@@ -226,8 +226,14 @@ describe('Masking email addresses', function() {
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskPassword(input, maskOptions);
-          expect(masked).to.equal(output, 'masked output does not match expected value');
+          try {
+            const masked = maskData.maskEmail2(input, maskOptions);
+            expect.fail('maskEmail2 did not throw an error')
+          }
+          catch(e) {
+            expect(e).to.be.a('string');
+            expect(e.startsWith('Bad config value', 'Shall be a Bad config value error')).to.be.true;
+          }
         });
       });
     });

--- a/tests/testPassword.js
+++ b/tests/testPassword.js
@@ -174,8 +174,14 @@ describe('Masking password', function() {
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskPassword(input, maskOptions);
-          expect(masked).to.equal(output, 'masked output does not match expected value');
+          try {
+            const masked = maskData.maskPassword(input, maskOptions);
+            expect.fail('maskPassword shall throw error on invalid input');
+          }
+          catch(e) {
+            expect(e).to.be.instanceOf(TypeError);
+            expect(e.message).to.equal('Invalid password parameter format');
+          }
         });
       });
     });

--- a/tests/testPhone.js
+++ b/tests/testPhone.js
@@ -122,7 +122,7 @@ describe('Masking phone numbers', function() {
         {
           title: 'test input as number',
           input: 1234567,
-          output: 'xx'      // TODO - ok to convert number into string? Or should it fail?
+          output: '12xxx67'      // ok to convert number into string? Or should it fail?
         },
       ]
 
@@ -152,8 +152,13 @@ describe('Masking phone numbers', function() {
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskPhone(input, maskOptions);
-          expect(masked).to.equal(output, 'masked output does not match expected value');
+          try {
+            const masked = maskData.maskPhone(input, maskOptions);
+            expect.fail('maskPhone shall throw an error');
+          } catch(e) {
+            expect(e).to.be.instanceOf(TypeError);
+            expect(e.message).to.equal('Invalid phone parameter format');
+          }
         });
       });
     });

--- a/tests/testString.js
+++ b/tests/testString.js
@@ -238,19 +238,25 @@ describe('Masking strings', function() {
         {
           title: 'test input as array',
           input: ['12', 'ab'],
-          output: 'xx'      // mask method seems to join all strings in the array into on big string and masks it?
+          output: 'aa'
         },
         {
           title: 'test input as object',
           input: {a: 'b', x: 'y'},
-          output: '12'  // json stringified and masked?
+          output: 'aa'
         }
       ]
 
       testData.forEach(({title, input, output}) => {
         it(`special input - ${title}`, function() {
-          const masked = maskData.maskString(input, maskOptions);
-          expect(masked).to.equal(output, 'masked output does not match expected value');
+          try {
+            const masked = maskData.maskString(input, maskOptions);
+            expect.fail('maskString invalid input format')
+          }
+          catch(e) {
+            expect(e).to.be.instanceOf(TypeError);
+            expect(e.message).to.equal('Invalid str parameter format');
+          }
         });
       });
     });


### PR DESCRIPTION
for all methods tested with mocha some test had failed. 
I unified the behaviour of the `mask*` methods regarding invalid inputs and adapted all test cases accordingly.

Now only two test cases for password masking fail. They test some edge cases you should decied how they shall be handled.
