### PR TITLE
Feature: Allow to mask URI strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const MaskPassword = require('./lib/maskService/PasswordMask');
 const MaskUuid = require('./lib/maskService/UuidMask');
 const JsonMask = require('./lib/maskService/JsonMask');
 const JwtMask = require('./lib/maskService/JwtMask');
+const UriMask = require('./lib/maskService/UriMask');
 const JsonGetSet = require('./lib/helpers/jsonGetSet');
 
 class MaskData {
@@ -50,6 +51,10 @@ class MaskData {
 
   static maskJwt(jwt, options) {
     return JwtMask.maskJwt(jwt, options);
+  }
+
+  static maskUri(uri, options) {
+    return UriMask.maskUri(uri, options);
   }
 
   static getInnerProperty(object, field) {

--- a/lib/helpers/Constants.js
+++ b/lib/helpers/Constants.js
@@ -63,6 +63,18 @@ const defaultUuidMaskOptions = {
   unmaskedEndCharacters: 0
 };
 
+const defaultUriMaskOptions = {
+  maskWith: '*',
+  maskProtocol: false,
+  maskUsername: true,
+  maskPassword: true,
+  maskHost: false,
+  maskPort: false,
+  maskPath: false,
+  maskQuery: true,
+  maskFragment: false
+};
+
 const defaultjsonMask2Configs = {
   cardMaskOptions: defaultCardMaskOptions,
   cardFields: [],
@@ -90,6 +102,7 @@ module.exports = {
   defaultStringMaskOptions,
   defaultStringMaskV2Options,
   defaultUuidMaskOptions,
+  defaultUriMaskOptions,
   defaultjsonMask2Configs,
   defaultJwtMaskOptions
 };

--- a/lib/helpers/MaskHelper.js
+++ b/lib/helpers/MaskHelper.js
@@ -334,13 +334,44 @@ class MaskHelper {
     }
   }
 
+  static validateUriMaskOptions(options) {
+    let reasons = [];
+
+    const booleanFields = [
+      'maskProtocol',
+      'maskUsername',
+      'maskPassword',
+      'maskHost',
+      'maskPort',
+      'maskPath',
+      'maskQuery',
+      'maskFragment'
+    ];
+
+    for (const field of booleanFields) {
+      if (options[field] === null || options[field] === undefined) {
+        options[field] = Constants.defaultUriMaskOptions[field];
+      } else if (typeof options[field] !== 'boolean') {
+        reasons.push(`${field} should be a boolean field`);
+      }
+    }
+
+    if (!options.maskWith || options.maskWith.toString().length <= 0) {
+      options.maskWith = '*';
+    }
+    if (reasons.length > 0) {
+      const badOptions = new BadOption('URI mask configuration', reasons);
+      badOptions.throwBadOptionException();
+    }
+  }
+
   static validateCardMaskOptions(options, cardLength) {
     let reasons = [];
     try {
       options.unmaskedStartDigits = parseInt(options.unmaskedStartDigits);
       options.unmaskedEndDigits = parseInt(options.unmaskedEndDigits);
       if (isNaN(options.unmaskedStartDigits) || isNaN(options.unmaskedEndDigits)) {
-        throw Error();
+        throw new Error("");
       }
     } catch (err) {
       reasons.push('unmaskedStartDigits and unmaskedEndDigits must be positive integers');

--- a/lib/maskService/UriMask.js
+++ b/lib/maskService/UriMask.js
@@ -1,0 +1,130 @@
+'use strict';
+const MaskHelper = require('../helpers/MaskHelper');
+const Constants = require('../helpers/Constants');
+
+class UriMask {
+  static maskUri(uri, options) {
+    if (!uri || typeof uri !== 'string') return uri;
+
+    const protocolEnd = uri.indexOf('://');
+    if (protocolEnd < 0) return uri;
+
+    options = options
+      ? MaskHelper.mapWithDefaultValues(options, Constants.defaultUriMaskOptions)
+      : Constants.defaultUriMaskOptions;
+    MaskHelper.validateUriMaskOptions(options);
+
+    const protocol = uri.substring(0, protocolEnd);
+    let remainder = uri.substring(protocolEnd + 3);
+
+    // Extract fragment
+    let fragment = '';
+    const fragmentIndex = remainder.indexOf('#');
+    if (fragmentIndex >= 0) {
+      fragment = remainder.substring(fragmentIndex + 1);
+      remainder = remainder.substring(0, fragmentIndex);
+    }
+
+    // Extract query
+    let query = '';
+    const queryIndex = remainder.indexOf('?');
+    if (queryIndex >= 0) {
+      query = remainder.substring(queryIndex + 1);
+      remainder = remainder.substring(0, queryIndex);
+    }
+
+    // Extract userinfo (user:password@)
+    let username = '';
+    let password = '';
+    let hasUserinfo = false;
+    let hasPassword = false;
+    const atIndex = remainder.indexOf('@');
+    if (atIndex >= 0) {
+      hasUserinfo = true;
+      const userinfo = remainder.substring(0, atIndex);
+      remainder = remainder.substring(atIndex + 1);
+      const colonIndex = userinfo.indexOf(':');
+      if (colonIndex >= 0) {
+        hasPassword = true;
+        username = userinfo.substring(0, colonIndex);
+        password = userinfo.substring(colonIndex + 1);
+      } else {
+        username = userinfo;
+      }
+    }
+
+    // Extract path
+    let path = '';
+    const pathIndex = remainder.indexOf('/');
+    if (pathIndex >= 0) {
+      path = remainder.substring(pathIndex + 1);
+      remainder = remainder.substring(0, pathIndex);
+    }
+
+    // remainder is now host or host:port
+    let host = remainder;
+    let port = '';
+    const portIndex = remainder.lastIndexOf(':');
+    if (portIndex >= 0) {
+      host = remainder.substring(0, portIndex);
+      port = remainder.substring(portIndex + 1);
+    }
+
+    // Build masked URI
+    let masked = '';
+
+    masked += options.maskProtocol
+      ? `${options.maskWith}`.repeat(protocol.length)
+      : protocol;
+    masked += '://';
+
+    if (hasUserinfo) {
+      masked += options.maskUsername
+        ? `${options.maskWith}`.repeat(username.length)
+        : username;
+      if (hasPassword) {
+        masked += ':';
+        masked += options.maskPassword
+          ? `${options.maskWith}`.repeat(password.length)
+          : password;
+      }
+      masked += '@';
+    }
+
+    masked += options.maskHost
+      ? `${options.maskWith}`.repeat(host.length)
+      : host;
+
+    if (port.length > 0) {
+      masked += ':';
+      masked += options.maskPort
+        ? `${options.maskWith}`.repeat(port.length)
+        : port;
+    }
+
+    if (path.length > 0) {
+      masked += '/';
+      masked += options.maskPath
+        ? `${options.maskWith}`.repeat(path.length)
+        : path;
+    }
+
+    if (query.length > 0) {
+      masked += '?';
+      masked += options.maskQuery
+        ? `${options.maskWith}`.repeat(query.length)
+        : query;
+    }
+
+    if (fragment.length > 0) {
+      masked += '#';
+      masked += options.maskFragment
+        ? `${options.maskWith}`.repeat(fragment.length)
+        : fragment;
+    }
+
+    return masked;
+  }
+}
+
+module.exports = UriMask;

--- a/tests/testUri.js
+++ b/tests/testUri.js
@@ -1,0 +1,239 @@
+'use strict';
+const maskData = require('../index');
+const expect = require('chai').expect;
+
+describe('Masking URI', function () {
+  describe('Mask URI with default options', function () {
+    // default options are this - let tests fail when defaults change
+    // const defaultUriMaskOptions = {
+    //   maskWith: '*',
+    //   maskProtocol: false,
+    //   maskUsername: true,
+    //   maskPassword: true,
+    //   maskHost: false,
+    //   maskPort: false,
+    //   maskPath: false,
+    //   maskQuery: true,
+    //   maskFragment: false
+    // };
+
+    let testData = [
+      {
+        title: 'Full URI with all parts',
+        input: 'http://admin:secret@example.com:8080/api/v1?token=abc123#section',
+        output: 'http://*****:******@example.com:8080/api/v1?************#section'
+      },
+      {
+        title: 'URI with user and password only',
+        input: 'https://user:pass@host.com',
+        output: 'https://****:****@host.com'
+      },
+      {
+        title: 'URI with user only (no password)',
+        input: 'ftp://admin@files.example.com/data',
+        output: 'ftp://*****@files.example.com/data'
+      },
+      {
+        title: 'Simple URI without credentials',
+        input: 'https://example.com',
+        output: 'https://example.com'
+      },
+      {
+        title: 'URI with port and query',
+        input: 'http://localhost:3000?debug=true',
+        output: 'http://localhost:3000?**********'
+      },
+      {
+        title: 'URI with path only',
+        input: 'https://api.example.com/v2/users',
+        output: 'https://api.example.com/v2/users'
+      }
+    ];
+
+    testData.forEach(({ title, input, output }) => {
+      it(`default mask - ${title}`, function () {
+        const masked = maskData.maskUri(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask URI with custom options - mask individual parts', function () {
+    const baseOptions = {
+      maskWith: '*',
+      maskProtocol: false,
+      maskUsername: false,
+      maskPassword: false,
+      maskHost: false,
+      maskPort: false,
+      maskPath: false,
+      maskQuery: false,
+      maskFragment: false
+    };
+
+    const fullUri = 'http://admin:secret@example.com:8080/api/v1?token=abc#top';
+
+    let testData = [
+      {
+        title: 'Mask only protocol',
+        output: '****://admin:secret@example.com:8080/api/v1?token=abc#top',
+        configKey: 'maskProtocol',
+        configValue: true
+      },
+      {
+        title: 'Mask only username',
+        output: 'http://*****:secret@example.com:8080/api/v1?token=abc#top',
+        configKey: 'maskUsername',
+        configValue: true
+      },
+      {
+        title: 'Mask only password',
+        output: 'http://admin:******@example.com:8080/api/v1?token=abc#top',
+        configKey: 'maskPassword',
+        configValue: true
+      },
+      {
+        title: 'Mask only host',
+        output: 'http://admin:secret@***********:8080/api/v1?token=abc#top',
+        configKey: 'maskHost',
+        configValue: true
+      },
+      {
+        title: 'Mask only port',
+        output: 'http://admin:secret@example.com:****/api/v1?token=abc#top',
+        configKey: 'maskPort',
+        configValue: true
+      },
+      {
+        title: 'Mask only path',
+        output: 'http://admin:secret@example.com:8080/******?token=abc#top',
+        configKey: 'maskPath',
+        configValue: true
+      },
+      {
+        title: 'Mask only query',
+        output: 'http://admin:secret@example.com:8080/api/v1?*********#top',
+        configKey: 'maskQuery',
+        configValue: true
+      },
+      {
+        title: 'Mask only fragment',
+        output: 'http://admin:secret@example.com:8080/api/v1?token=abc#***',
+        configKey: 'maskFragment',
+        configValue: true
+      }
+    ];
+
+    testData.forEach(({ title, output, configKey, configValue }) => {
+      const config = JSON.parse(JSON.stringify(baseOptions));
+      config[configKey] = configValue;
+      it(`custom mask - ${title}`, function () {
+        const masked = maskData.maskUri(fullUri, config);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Mask URI with custom maskWith character', function () {
+    it('should use custom mask character', function () {
+      const options = {
+        maskWith: '#',
+        maskUsername: true,
+        maskPassword: true
+      };
+      const masked = maskData.maskUri('https://user:pass@host.com', options);
+      expect(masked).to.equal('https://####:####@host.com');
+    });
+  });
+
+  describe('Mask all URI parts', function () {
+    it('should mask every part of the URI', function () {
+      const options = {
+        maskWith: '*',
+        maskProtocol: true,
+        maskUsername: true,
+        maskPassword: true,
+        maskHost: true,
+        maskPort: true,
+        maskPath: true,
+        maskQuery: true,
+        maskFragment: true
+      };
+      const masked = maskData.maskUri(
+        'http://admin:secret@example.com:8080/api/v1?token=abc#top',
+        options
+      );
+      expect(masked).to.equal(
+        '****://*****:******@***********:****/******?*********#***'
+      );
+    });
+  });
+
+  describe('Edge cases', function () {
+    let testData = [
+      {
+        title: 'No protocol separator - return as is',
+        input: 'not-a-uri',
+        output: 'not-a-uri'
+      },
+      {
+        title: 'Empty string',
+        input: '',
+        output: ''
+      },
+      {
+        title: 'Protocol only',
+        input: 'http://',
+        output: 'http://'
+      },
+      {
+        title: 'URI with empty password',
+        input: 'http://user:@host.com',
+        output: 'http://****:@host.com'
+      }
+    ];
+
+    testData.forEach(({ title, input, output }) => {
+      it(`edge case - ${title}`, function () {
+        const masked = maskData.maskUri(input);
+        expect(masked).to.equal(output, 'masked output does not match expected value');
+      });
+    });
+  });
+
+  describe('Non-string inputs - input will not be masked', function () {
+    let testData = [
+      {
+        title: 'test input as number',
+        input: 12
+      },
+      {
+        title: 'test input as array',
+        input: ['http://example.com']
+      },
+      {
+        title: 'test input as object',
+        input: { uri: 'http://example.com' }
+      },
+      {
+        title: 'test input as boolean',
+        input: false
+      },
+      {
+        title: 'undefined uri',
+        input: undefined
+      },
+      {
+        title: 'null uri',
+        input: null
+      }
+    ];
+
+    testData.forEach(({ title, input }) => {
+      it(`non string input - ${title}`, function () {
+        const masked = maskData.maskUri(input);
+        expect(masked).to.equal(input, 'Improper input');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add feature to mask URI strings. Allowing to mask, protocol, username, password, host, port, path, query and fragment.

Let me know if there is something to be changed. My team and I are using this library to hide sensitive data, and we need to hide URI data too. This is why I made the PR.